### PR TITLE
[Feat] 주문내역 뷰 - 총 수량&가격 업데이트, 주문취소 액션 설정

### DIFF
--- a/Oripresso.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Oripresso.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -4,7 +4,7 @@
     {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SnapKit/SnapKit",
+      "location" : "https://github.com/SnapKit/SnapKit.git",
       "state" : {
         "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
         "version" : "5.7.1"

--- a/Oripresso/OrderList.storyboard
+++ b/Oripresso/OrderList.storyboard
@@ -265,7 +265,7 @@
         <image name="plus" width="18" height="19"/>
         <image name="titleBar" width="393" height="38"/>
         <systemColor name="systemGray2Color">
-            <color red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Oripresso/OrderList.storyboard
+++ b/Oripresso/OrderList.storyboard
@@ -180,9 +180,12 @@
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9rk-gD-0DJ">
                                         <rect key="frame" x="247.66666666666666" y="15" width="117.33333333333334" height="62"/>
-                                        <color key="tintColor" red="0.098039215686274508" green="0.25098039215686274" blue="0.14509803921568626" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="filled" title="주문하기">
+                                        <buttonConfiguration key="configuration" style="plain" title="주문하기" cornerStyle="small">
+                                            <backgroundConfiguration key="background">
+                                                <color key="backgroundColor" red="0.098039215690000001" green="0.25098039220000001" blue="0.1450980392" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </backgroundConfiguration>
                                             <fontDescription key="titleFontDescription" type="system" weight="semibold" pointSize="20"/>
                                         </buttonConfiguration>
                                         <connections>
@@ -191,9 +194,12 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tnB-nw-vxr">
                                         <rect key="frame" x="158" y="15" width="83.666666666666686" height="62"/>
-                                        <color key="tintColor" systemColor="systemGray2Color"/>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="filled" title="주문취소">
+                                        <buttonConfiguration key="configuration" style="plain" title="주문취소" cornerStyle="small">
+                                            <backgroundConfiguration key="background">
+                                                <color key="backgroundColor" systemColor="systemGray2Color"/>
+                                            </backgroundConfiguration>
                                             <fontDescription key="titleFontDescription" type="system" weight="semibold" pointSize="14"/>
                                         </buttonConfiguration>
                                         <connections>

--- a/Oripresso/OrderListViewController.swift
+++ b/Oripresso/OrderListViewController.swift
@@ -26,8 +26,12 @@ class OrderListViewController: UIViewController {
     @IBOutlet weak var totalPriceLabel: UILabel!
     
     // MARK: - Total
-    var totalQuantity: Int = self.selectedMen
-    self.totalQuantityLabel.text = String()
+    func updateTotal() {
+        var totalQuantity: Int = selectedMenu.reduce(0) { partialResult, selectedMenu in
+            return partialResult + selectedMenu.quantity
+        }
+        self.totalQuantityLabel.text = String(totalQuantity)
+    }
     
     // MARK: - Cancel
     @IBAction func tapCancelButton(_ sender: UIButton) {
@@ -70,15 +74,15 @@ extension OrderListViewController: UITableViewDataSource {
             return UITableViewCell()
         }
         
-        var item = selectedMenu[indexPath.row]
         cell.quantityVariance = { variance in
-            item.quantity += variance
-            if item.quantity <= 0 {
-                item.quantity = 1   // 수량이 1 이하로 내려가지 않도록 함
+            self.selectedMenu[indexPath.row].quantity += variance
+            if self.selectedMenu[indexPath.row].quantity <= 0 {
+                self.selectedMenu[indexPath.row].quantity = 1   // 수량이 1 이하로 내려가지 않도록 함
             }
-            cell.updateLabels(item)
+            cell.updateLabels(self.selectedMenu[indexPath.row])
+            self.updateTotal()
         }
-        cell.configure(item, index: indexPath.row + 1)
+        cell.configure(selectedMenu[indexPath.row], index: indexPath.row + 1)
         cell.selectionStyle = .none
         return cell
     }

--- a/Oripresso/OrderListViewController.swift
+++ b/Oripresso/OrderListViewController.swift
@@ -34,8 +34,16 @@ class OrderListViewController: UIViewController {
             return partialResult + (item.price * item.quantity)
         }
         self.totalQuantityLabel.text = String(totalQuantity)
-        self.totalPriceLabel.text = String(totalPrice)
+        self.totalPriceLabel.text = "\(numberFormatter.string(from: NSNumber(value: totalPrice)) ?? "0") ₩"
     }
+    
+    
+    // MARK: - NumberFormatter
+    let numberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
     
     // MARK: - Cancel
     @IBAction func tapCancelButton(_ sender: UIButton) {

--- a/Oripresso/OrderListViewController.swift
+++ b/Oripresso/OrderListViewController.swift
@@ -45,19 +45,22 @@ class OrderListViewController: UIViewController {
         return formatter
     }()
     
-    // MARK: - Cancel
+    // MARK: - CancelOrder
     @IBAction func tapCancelButton(_ sender: UIButton) {
         let alert = UIAlertController(title: "주문을 취소하시겠습니까?", message: "담긴 주문은 전체 삭제 되고 메인화면으로 돌아갑니다", preferredStyle: .alert)
         let orderCancelAction = UIAlertAction(title: "아니요", style: .destructive) { action in
         }
         let orderDidTapButton = UIAlertAction(title: "예", style: .default) { action in
+            self.selectedMenu = []               // selectedMenu 초기화
+            self.orderListTableView.reloadData() // 테이블뷰 업데이트
+            self.updateTotal()                   // total bar 업데이트
         }
         alert.addAction(orderCancelAction)
         alert.addAction(orderDidTapButton)
         
         self.present(alert, animated: true)
     }
-    // MARK: - Order
+    // MARK: - ConductOrder
     @IBAction func tapOrderButton(_ sender: UIButton) {
         let alert = UIAlertController(title: "주문하시겠습니까?", message: nil, preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: "아니요", style: .destructive) { action in

--- a/Oripresso/OrderListViewController.swift
+++ b/Oripresso/OrderListViewController.swift
@@ -37,7 +37,6 @@ class OrderListViewController: UIViewController {
         self.totalPriceLabel.text = "\(numberFormatter.string(from: NSNumber(value: totalPrice)) ?? "0") ₩"
     }
     
-    
     // MARK: - NumberFormatter
     let numberFormatter = {
         let formatter = NumberFormatter()

--- a/Oripresso/OrderListViewController.swift
+++ b/Oripresso/OrderListViewController.swift
@@ -27,10 +27,14 @@ class OrderListViewController: UIViewController {
     
     // MARK: - Total
     func updateTotal() {
-        var totalQuantity: Int = selectedMenu.reduce(0) { partialResult, selectedMenu in
-            return partialResult + selectedMenu.quantity
+        let totalQuantity: Int = selectedMenu.reduce(0) { partialResult, item in
+            return partialResult + item.quantity
+        }
+        let totalPrice: Int = selectedMenu.reduce(0) { partialResult, item in
+            return partialResult + (item.price * item.quantity)
         }
         self.totalQuantityLabel.text = String(totalQuantity)
+        self.totalPriceLabel.text = String(totalPrice)
     }
     
     // MARK: - Cancel
@@ -60,6 +64,7 @@ class OrderListViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        updateTotal()
         orderListTableView.dataSource = self
     }
 }


### PR DESCRIPTION
## What is the PR? 🔍
- table에서 quantity 변동될 때마다 하단에 총 수량&가격 레이블도 업데이트
- [주문취소] 탭 > [예] 탭할 때 selectedMenu 초기화하고 뷰 업데이트

## Changes 📝
- MainView에서 OrderList로 넘어올 때 하단 [취소하기], [주문하기] 버튼 색깔이 기본 파란색으로 보이는 버그가 있었습니다. 해결을 위해 버튼 스타일을 filled -> plain으로 변경했습니다.

## Screenshot 📷
|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/NBCampArchive/Oripresso/assets/157277372/e1402b90-fd97-405e-943d-f8cd0b6fcdf6" width ="250">|

## Related Issues 💭
- Resolved: #4 