### PR TITLE
[Feat] OrderList에서 MainView로 이동할 때 selectedMenu 데이터 전달, dessert 오타 수정

### DIFF
--- a/Oripresso/CoffeeMenu.swift
+++ b/Oripresso/CoffeeMenu.swift
@@ -9,13 +9,13 @@ import Foundation
 struct CafeMenu: Codable {
     let coffee: Category
     let nonCoffee: Category
-    let desert: Category
+    let dessert: Category
     let bread: Category
     
     enum CodingKeys: String, CodingKey {
         case coffee = "Coffee"
         case nonCoffee = "Non-Coffee"
-        case desert = "Desert"
+        case dessert = "Dessert"
         case bread = "Bread"
     }
 }

--- a/Oripresso/MainView.storyboard
+++ b/Oripresso/MainView.storyboard
@@ -40,7 +40,7 @@
                                 <segments>
                                     <segment title="Coffee"/>
                                     <segment title="Non-Coffee"/>
-                                    <segment title="Desert"/>
+                                    <segment title="Dessert"/>
                                     <segment title="Bread"/>
                                 </segments>
                                 <connections>

--- a/Oripresso/MainViewController.swift
+++ b/Oripresso/MainViewController.swift
@@ -43,7 +43,7 @@ class MainViewController: UIViewController {
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        viewDidLoad()
         if shouldResetDisplayedMenus {
             resetDisplayedMenus()
             shouldResetDisplayedMenus = false
@@ -171,6 +171,7 @@ class MainViewController: UIViewController {
             print(selectedMenus)
         }
     }
+    
 }
 
 // MARK: - UISegmentedControl Extension

--- a/Oripresso/MainViewController.swift
+++ b/Oripresso/MainViewController.swift
@@ -95,8 +95,8 @@ class MainViewController: UIViewController {
             category = cafeMenu?.coffee
         case "Non-Coffee":
             category = cafeMenu?.nonCoffee
-        case "Desert":
-            category = cafeMenu?.desert
+        case "Dessert":
+            category = cafeMenu?.dessert
         case "Bread":
             category = cafeMenu?.bread
         default:
@@ -117,8 +117,8 @@ class MainViewController: UIViewController {
             category = cafeMenu?.coffee
         case "Non-Coffee":
             category = cafeMenu?.nonCoffee
-        case "Desert":
-            category = cafeMenu?.desert
+        case "Dessert":
+            category = cafeMenu?.dessert
         case "Bread":
             category = cafeMenu?.bread
         default:
@@ -234,8 +234,8 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource {
                 menu = cafeMenu.coffee.menus[indexPath.row]
             case "Non-Coffee":
                 menu = cafeMenu.nonCoffee.menus[indexPath.row]
-            case "Desert":
-                menu = cafeMenu.desert.menus[indexPath.row]
+            case "Dessert":
+                menu = cafeMenu.dessert.menus[indexPath.row]
             case "Bread":
                 menu = cafeMenu.bread.menus[indexPath.row]
             default:
@@ -268,8 +268,8 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource {
                 menu = cafeMenu.coffee.menus[indexPath.row]
             case "Non-Coffee":
                 menu = cafeMenu.nonCoffee.menus[indexPath.row]
-            case "Desert":
-                menu = cafeMenu.desert.menus[indexPath.row]
+            case "Dessert":
+                menu = cafeMenu.dessert.menus[indexPath.row]
             case "Bread":
                 menu = cafeMenu.bread.menus[indexPath.row]
             default:

--- a/Oripresso/OrderListViewController.swift
+++ b/Oripresso/OrderListViewController.swift
@@ -86,6 +86,13 @@ class OrderListViewController: UIViewController {
         self.navigationController?.navigationBar.topItem?.backButtonTitle = ""
         self.navigationController?.navigationBar.tintColor = UIColor(red: 0.098, green: 0.251, blue: 0.145, alpha: 1)
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        // MainViewController로 메뉴 데이터 보내기
+        if let mainViewController = self.navigationController?.viewControllers.first as? MainViewController {
+            mainViewController.selectedMenus = self.selectedMenu
+        }
+    }
 }
 
 extension OrderListViewController: UITableViewDataSource {

--- a/Oripresso/en.lproj/CoffeeJson.json
+++ b/Oripresso/en.lproj/CoffeeJson.json
@@ -103,7 +103,7 @@
       }
     ]
   },
-  "Desert": {
+  "Dessert": {
     "menus": [
       {
         "image": "ganacheCake",


### PR DESCRIPTION
## What is the PR? 🔍
 - OrderList에서 MainView로 이동할 때 selectedMenu 데이터 전달
 - 오타 수정: desert -> dessert

## Changes 📝

## Screenshot 📷
|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/NBCampArchive/Oripresso/assets/157277372/d424c16d-630d-4862-bffe-5a3b5e63994d" width ="250">|

## To Reviewers 🙏
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## Related Issues 💭
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #31 