### PR TITLE
[Fix] 처음 Coffee 메뉴를 불러올 때 2번 불러오는 오류 수정

### DIFF
--- a/Oripresso/MainViewController.swift
+++ b/Oripresso/MainViewController.swift
@@ -43,7 +43,7 @@ class MainViewController: UIViewController {
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        viewDidLoad()
+        uiTableView.reloadData()
         selectedLabel.text = String(selectedMenus.count)
         if shouldResetDisplayedMenus {
             resetDisplayedMenus()


### PR DESCRIPTION
## What is the PR? 🔍
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 처음 Coffee 메뉴를 불러올 때 2번 불러오는 오류 수정

## Changes 📝
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->

## Screenshot 📷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요.(선택) -->

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| merge | <img width="311" alt="스크린샷 2024-04-07 오후 5 52 05" src="https://github.com/NBCampArchive/Oripresso/assets/133753824/9f9f73b1-3788-4d7c-9dd7-559e4c61d80e">|

## To Reviewers 🙏
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## Related Issues 💭
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #